### PR TITLE
Correcting a typo in the image name for the exporter.

### DIFF
--- a/deployments/ytsaurus-excel-chart/values.yaml
+++ b/deployments/ytsaurus-excel-chart/values.yaml
@@ -2,7 +2,7 @@ replicaCount: 1
 
 image:
   exporter:
-    repository: ghcr.io/ytsaurus/excel-uploader
+    repository: ghcr.io/ytsaurus/excel-exporter
     pullPolicy: IfNotPresent
     tag: "dev"
   uploader:


### PR DESCRIPTION
wrong image was used by default