### PR TITLE
Improve debug tools in exporter and uploader docker images

### DIFF
--- a/exporter/build/docker/Dockerfile
+++ b/exporter/build/docker/Dockerfile
@@ -9,12 +9,48 @@ COPY ./excel-exporter /usr/bin/excel-exporter
 # CREDITS files with licenses for all binaries.
 COPY ./credits/excel-exporter.CREDITS /usr/bin/excel-exporter.CREDITS
 
-RUN apt update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y \
-  curl \
-  less \
-  gdb \
-  lsof \
-  strace \
-  telnet \
-  dnsutils \
+# Install debug tools
+RUN <<-EOT
+#!/bin/bash
+set -eux -o pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+export TZ=Etc/UTC
+
+apt-get update -q --error-on=any
+
+packages=(
+  curl
+  dnsutils
+  gdb
+  google-perftools
+  htop
+  iperf
+  iproute2
   iputils-ping
+  jq
+  less
+  lsb-release
+  lsof
+  ncdu
+  netcat-openbsd
+  procps
+  python3
+  python3-pip
+  strace
+  tcpdump
+  telnet
+  tini
+  unzip
+  vim
+  wget
+  zstd
+)
+
+apt-get install -y --no-install-recommends "${packages[@]}"
+
+# Clean up to reduce image size
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+
+EOT

--- a/uploader/build/docker/Dockerfile
+++ b/uploader/build/docker/Dockerfile
@@ -9,12 +9,48 @@ COPY ./excel-uploader /usr/bin/excel-uploader
 # CREDITS files with licenses for all binaries.
 COPY ./credits/excel-uploader.CREDITS /usr/bin/excel-uploader.CREDITS
 
-RUN apt update && DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt install -y \
-  curl \
-  less \
-  gdb \
-  lsof \
-  strace \
-  telnet \
-  dnsutils \
+# Install debug tools
+RUN <<-EOT
+#!/bin/bash
+set -eux -o pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+export TZ=Etc/UTC
+
+apt-get update -q --error-on=any
+
+packages=(
+  curl
+  dnsutils
+  gdb
+  google-perftools
+  htop
+  iperf
+  iproute2
   iputils-ping
+  jq
+  less
+  lsb-release
+  lsof
+  ncdu
+  netcat-openbsd
+  procps
+  python3
+  python3-pip
+  strace
+  tcpdump
+  telnet
+  tini
+  unzip
+  vim
+  wget
+  zstd
+)
+
+apt-get install -y --no-install-recommends "${packages[@]}"
+
+# Clean up to reduce image size
+apt-get clean
+rm -rf /var/lib/apt/lists/*
+
+EOT


### PR DESCRIPTION
The list of tools is taken from [ytsaurus image](https://github.com/ytsaurus/ytsaurus/blob/main/yt/docker/ytsaurus/Dockerfile#L56-L114) with slight adjustments

270MB -> 347MB